### PR TITLE
Fix FeedRate and Homing

### DIFF
--- a/Marlin/src/lcd/malyanlcd.cpp
+++ b/Marlin/src/lcd/malyanlcd.cpp
@@ -124,7 +124,7 @@ void write_to_lcd(const char * const message) {
  */
 void process_lcd_c_command(const char* command) {
   switch (command[0]) {
-    case 'C': {
+    case 'S': {
       int raw_feedrate = atoi(command + 1);
       feedrate_percentage = raw_feedrate * 10;
       feedrate_percentage = constrain(feedrate_percentage, 10, 999);
@@ -330,12 +330,7 @@ void process_lcd_s_command(const char* command) {
       );
       write_to_lcd(message_buffer);
     } break;
-
-    case 'H':
-      // Home all axis
-      enqueue_and_echo_command("G28");
-      break;
-
+    
     case 'L': {
       #if ENABLED(SDSUPPORT)
         if (!card.isDetected()) card.initsd();


### PR DESCRIPTION
### Description

This fixes two issues with the Malyan cmd parsing. The first is that when a feedrate is selected on the LCD it sends {C:SXY} where X and Y are relative to 1.0 (100%) So 11 is 1.1 or 110%. The existing code is looking for C but the C has been parsed earlier so needs to actually check for 'S'.

Also the UI has one homing cmd which is {P:H} the code in the P processing function correctly handles it but there was another function incorrectly looking for it, removed that section.

### Benefits

Fixes feedrate cmds from the UI and removes unncessary code.
