### PR TITLE
Pr/3

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -142,7 +142,7 @@
 
 // This defines the number of extruders
 // :[1, 2, 3, 4, 5, 6, 7, 8]
-#define EXTRUDERS 1
+#define EXTRUDERS 2
 
 // Generally expected filament diameter (1.75, 2.85, 3.0, ...). Used for Volumetric, Filament Width Sensor, etc.
 #define DEFAULT_NOMINAL_FILAMENT_DIA 1.75
@@ -417,7 +417,7 @@
  *   999 : Dummy Table that ALWAYS reads 100°C or the temperature defined below.
  */
 #define TEMP_SENSOR_0 1
-#define TEMP_SENSOR_1 0
+#define TEMP_SENSOR_1 1
 #define TEMP_SENSOR_2 0
 #define TEMP_SENSOR_3 0
 #define TEMP_SENSOR_4 0
@@ -447,28 +447,28 @@
 
 // Below this temperature the heater will be switched off
 // because it probably indicates a broken thermistor wire.
-#define HEATER_0_MINTEMP   5
-#define HEATER_1_MINTEMP   5
-#define HEATER_2_MINTEMP   5
-#define HEATER_3_MINTEMP   5
-#define HEATER_4_MINTEMP   5
-#define HEATER_5_MINTEMP   5
-#define HEATER_6_MINTEMP   5
-#define HEATER_7_MINTEMP   5
-#define BED_MINTEMP        5
+#define HEATER_0_MINTEMP   -200
+#define HEATER_1_MINTEMP   -200
+#define HEATER_2_MINTEMP   -200
+#define HEATER_3_MINTEMP   -200
+#define HEATER_4_MINTEMP   -200
+#define HEATER_5_MINTEMP   -200
+#define HEATER_6_MINTEMP   -200
+#define HEATER_7_MINTEMP   -200
+#define BED_MINTEMP        -200
 
 // Above this temperature the heater will be switched off.
 // This can protect components from overheating, but NOT from shorts and failures.
 // (Use MINTEMP for thermistor short/failure protection.)
-#define HEATER_0_MAXTEMP 275
-#define HEATER_1_MAXTEMP 275
-#define HEATER_2_MAXTEMP 275
-#define HEATER_3_MAXTEMP 275
-#define HEATER_4_MAXTEMP 275
-#define HEATER_5_MAXTEMP 275
-#define HEATER_6_MAXTEMP 275
-#define HEATER_7_MAXTEMP 275
-#define BED_MAXTEMP      150
+#define HEATER_0_MAXTEMP 700
+#define HEATER_1_MAXTEMP 700
+#define HEATER_2_MAXTEMP 700
+#define HEATER_3_MAXTEMP 700
+#define HEATER_4_MAXTEMP 700
+#define HEATER_5_MAXTEMP 700
+#define HEATER_6_MAXTEMP 700
+#define HEATER_7_MAXTEMP 700
+#define BED_MAXTEMP      700
 
 //===========================================================================
 //============================= PID Settings ================================
@@ -598,9 +598,9 @@
  * details can be tuned in Configuration_adv.h
  */
 
-#define THERMAL_PROTECTION_HOTENDS // Enable thermal protection for all extruders
-#define THERMAL_PROTECTION_BED     // Enable thermal protection for the heated bed
-#define THERMAL_PROTECTION_CHAMBER // Enable thermal protection for the heated chamber
+//#define THERMAL_PROTECTION_HOTENDS // Enable thermal protection for all extruders
+//#define THERMAL_PROTECTION_BED     // Enable thermal protection for the heated bed
+//#define THERMAL_PROTECTION_CHAMBER // Enable thermal protection for the heated chamber
 
 //===========================================================================
 //============================= Mechanical Settings =========================
@@ -1682,7 +1682,7 @@
  * you must uncomment the following option or it won't work.
  *
  */
-//#define SDSUPPORT
+#define SDSUPPORT
 
 /**
  * SD CARD: SPI SPEED
@@ -2195,7 +2195,7 @@
 // Use software PWM to drive the fan, as for the heaters. This uses a very low frequency
 // which is not as annoying as with the hardware PWM. On the other hand, if this frequency
 // is too low, you should also increment SOFT_PWM_SCALE.
-//#define FAN_SOFT_PWM
+#define FAN_SOFT_PWM
 
 // Incrementing this by 1 will double the software PWM frequency,
 // affecting heaters, and the fan if FAN_SOFT_PWM is enabled.

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -104,7 +104,7 @@
  *
  * :[-1, 0, 1, 2, 3, 4, 5, 6, 7]
  */
-#define SERIAL_PORT 0
+#define SERIAL_PORT 1
 
 /**
  * Select a secondary serial port on the board to use for communication with the host.
@@ -121,14 +121,14 @@
  *
  * :[2400, 9600, 19200, 38400, 57600, 115200, 250000, 500000, 1000000]
  */
-#define BAUDRATE 250000
+#define BAUDRATE 115200
 
 // Enable the Bluetooth serial interface on AT90USB devices
 //#define BLUETOOTH
 
 // Choose the name from boards.h that matches your setup
 #ifndef MOTHERBOARD
-  #define MOTHERBOARD BOARD_RAMPS_14_EFB
+  #define MOTHERBOARD BOARD_LERDGE_S 
 #endif
 
 // Name displayed in the LCD "Ready" message and Info menu
@@ -424,7 +424,7 @@
 #define TEMP_SENSOR_5 0
 #define TEMP_SENSOR_6 0
 #define TEMP_SENSOR_7 0
-#define TEMP_SENSOR_BED 0
+#define TEMP_SENSOR_BED 1
 #define TEMP_SENSOR_PROBE 0
 #define TEMP_SENSOR_CHAMBER 0
 
@@ -2127,7 +2127,7 @@
 // TFT display with optional touch screen
 // Color Marlin UI with standard menu system
 //
-//#define TFT_320x240
+#define TFT_320x240
 //#define TFT_320x240_SPI
 
 //
@@ -2135,7 +2135,7 @@
 // Mandatory for SPI screens with no MISO line
 // Available drivers are: ST7735, ST7789, ST7796, ILI9328, ILI9341, ILI9488
 //
-//#define TFT_DRIVER AUTO
+#define TFT_DRIVER ST7796
 
 //
 // FSMC display (MKS Robin, Alfawise U20, JGAurora A5S, REXYZ A1, etc.)
@@ -2165,7 +2165,7 @@
 //
 // ADS7843/XPT2046 ADC Touchscreen such as ILI9341 2.8
 //
-//#define TOUCH_SCREEN
+#define TOUCH_SCREEN
 #if ENABLED(TOUCH_SCREEN)
   #define BUTTON_DELAY_EDIT  50 // (ms) Button repeat delay for edit screens
   #define BUTTON_DELAY_MENU 250 // (ms) Button repeat delay for menus

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -3444,7 +3444,7 @@
 //
 // M43 - display pin status, toggle pins, watch pins, watch endstops & toggle LED, test servo probe
 //
-//#define PINS_DEBUGGING
+#define PINS_DEBUGGING
 
 // Enable Marlin dev mode which adds some special commands
 //#define MARLIN_DEV_MODE

--- a/Marlin/src/pins/stm32f4/pins_LERDGE_S.h
+++ b/Marlin/src/pins/stm32f4/pins_LERDGE_S.h
@@ -35,18 +35,19 @@
 //
 // Servos
 //
-//#define SERVO0_PIN                        PD12 //unchecked, most likely wrong, board has a servo connector
+#define SERVO0_PIN                          PD12 //confirmed
 //#define SERVO1_PIN                        -1
 
 //
 // Limit Switches
 //
-#define X_MIN_PIN                          PG9 //confirmed
-#define Y_MIN_PIN                          PG10 //confirmed
-#define Z_MIN_PIN                          PG11 //confirmed
-#define X_MAX_PIN                          PG12 //confirmed
-#define Y_MAX_PIN                          PG13 //confirmed
-#define Z_MAX_PIN                          PG14 //confirmed
+#define X_MIN_PIN                           PG9 //confirmed
+#define Y_MIN_PIN                           PG10 //confirmed
+#define Z_MIN_PIN                           PG11 //confirmed
+
+#define X_MAX_PIN                           PG12 //confirmed
+#define Y_MAX_PIN                           PG13 //confirmed
+#define Z_MAX_PIN                           PG14 //confirmed
 
 //
 // Filament runout
@@ -57,7 +58,7 @@
 // Z Probe (when not Z_MIN_PIN)
 //
 #ifndef Z_MIN_PROBE_PIN
-  #define Z_MIN_PROBE_PIN  PG8 //confirmed
+  #define Z_MIN_PROBE_PIN                   PG8 //confirmed
 #endif
 
 //
@@ -72,7 +73,7 @@
 
 #define Y_STEP_PIN                          PF10 //confirmed 
 #define Y_DIR_PIN                           PF11 //confirmed 
-#define Y_ENABLE_PIN                        PF9  //confirmed 
+#define Y_ENABLE_PIN                        PF9 //confirmed 
 //#ifndef Y_CS_PIN
 //  #define Y_CS_PIN                        -1 //no idea
 //#endif
@@ -113,18 +114,14 @@
 #define HEATER_BED_PIN                      PA3 //confirmed
 
 
-#ifndef FAN_PIN
-  #define FAN_PIN                         PA15
-#endif
-
-//#define FAN0_PIN                            PA15 //heater 0 fan 1 //confirmed
+#define FAN_PIN                             PA15 //heater 0 fan 1 //confirmed
 #define FAN1_PIN                            PB10 //heater 1 fan 2 //confirmed
-#define FAN2_PIN                            PF5  //heater 0 fan 2 and heater 1 fan 2 (two sockets, switched together) //confirmed
+#define FAN2_PIN                            PF5  //heater 0 fan 2 and heater 1 fan 1 (two sockets, switched together) //confirmed
 
 
-#ifndef E0_AUTO_FAN_PIN
-  #define E0_AUTO_FAN_PIN                   FAN2_PIN
-#endif
+//#ifndef E0_AUTO_FAN_PIN
+//  #define E0_AUTO_FAN_PIN                   FAN2_PIN
+//#endif
 
 //
 // Prusa i3 MK2 Multi Material Multiplexer Support
@@ -135,29 +132,35 @@
 //
 // LED / Lighting
 //
-#define CASE_LIGHT_PIN                 PC7 //board has two LED strip connectors (this is the on/off)
-//#define CASE_LIGHT_PIN_DO                 -1
-//#define NEOPIXEL_PIN                      -1 //board supports RGB lightstrip, need to check pins 
+//Lerdge-S board has two LED connectors (this is the one on the mainboard)
+#define CASE_LIGHT_PIN                      PC7 //confirmed
+
+//on the dual extrusion addon board is a RGB connector
+#define RGB_LED_R_PIN                       PC7 //shared with the mainboard LED connector, confirmed
+#define RGB_LED_G_PIN                       PB0 //confirmed
+#define RGB_LED_B_PIN                       PB1 //confirmed
+
 
 //
 // Misc. Functions
 //
 #define SDSS                                PC11 //unchecked, will test sd access later
-#define LED_PIN                             PC6   //onboard LED , confirmed
-#define PS_ON_PIN                           -1    //board has a power monitor socket, pin PB2
-#define KILL_PIN                            -1
-#define POWER_LOSS_PIN                      -1    // Power-loss / nAC_FAULT
-
-#define SCK_PIN                             PC12 //unchecked, will test sd access later
-#define MISO_PIN                            PC8  //unchecked, will test sd access later
-#define MOSI_PIN                            PD2 //unchecked, will test sd access later
-#define SS_PIN                              PC11 //unchecked, will test sd access later
+#define LED_PIN                             PC6   //mainboard LED, confirmed
+#define PS_ON_PIN                           PB2   //board has a power module connector, confirmed
+#define KILL_PIN                            -1    //there is no reset button on the lcd
+#define POWER_LOSS_PIN                      -1    //PB2 could be used for this as well
 
 //
 // SD support
 //
-//#define SDIO_SUPPORT
-#define SD_DETECT_PIN                       PG15 //maybe? will test sd access later
+#define SDIO_SUPPORT
+
+#define SCK_PIN                             PC12 //confirmed working 
+#define MISO_PIN                            PC8 //confirmed working 
+#define MOSI_PIN                            PD2 //confirmed working 
+#define SS_PIN                              PC11 //confirmed working 
+
+#define SD_DETECT_PIN                       PG15 //confirmed
 
 //
 // LCD / Controller
@@ -170,11 +173,11 @@
 #define BTN_EN2                             PC15 //confirmed
 #define BTN_ENC                             PC13 //confirmed
 
-#define TFT_RESET_PIN                       PD6 //unchecked, most likely wrong
-#define TFT_BACKLIGHT_PIN                   PD3  //confirmed (well, the LCD is off, but I cannot see if it is only the backlight)
+#define TFT_RESET_PIN                       PD6 //unchecked, unsure how to test
+#define TFT_BACKLIGHT_PIN                   PD3 //confirmed (well, this pin switches the LCD off, but I cannot see if it is only the backlight)
 
-#define TFT_CS_PIN                         PD7 //TFT works, so all ok?
-#define TFT_RS_PIN                         PD11 //TFT works, so all ok?
+#define TFT_CS_PIN                          PD7 //TFT works
+#define TFT_RS_PIN                          PD11 //TFT works
 
 #define TOUCH_CS_PIN                        PB6 //there is touch, but calibration is off
 #define TOUCH_SCK_PIN                       PB3 //there is touch, but calibration is off

--- a/Marlin/src/pins/stm32f4/pins_LERDGE_S.h
+++ b/Marlin/src/pins/stm32f4/pins_LERDGE_S.h
@@ -41,21 +41,24 @@
 //
 // Limit Switches
 //
-#define X_STOP_PIN                          PB12 //unchecked, most likely wrong
-#define Y_STOP_PIN                          PB13 //unchecked, most likely wrong
-#define Z_STOP_PIN                          PB14 //unchecked, most likely wrong
+#define X_MIN_PIN                          PG9 //confirmed
+#define Y_MIN_PIN                          PG10 //confirmed
+#define Z_MIN_PIN                          PG11 //confirmed
+#define X_MAX_PIN                          PG12 //confirmed
+#define Y_MAX_PIN                          PG13 //confirmed
+#define Z_MAX_PIN                          PG14 //confirmed
 
 //
 // Filament runout
 //
-#define FIL_RUNOUT_PIN                      PE1 //unchecked, most likely wrong
+#define FIL_RUNOUT_PIN                      PC5 //confirmed
 
 //
 // Z Probe (when not Z_MIN_PIN)
 //
-//#ifndef Z_MIN_PROBE_PIN
-//  #define Z_MIN_PROBE_PIN  PB15 //unchecked, most likely wrong, board has a probe switch connector
-//#endif
+#ifndef Z_MIN_PROBE_PIN
+  #define Z_MIN_PROBE_PIN  PG815 //confirmed
+#endif
 
 //
 // Steppers
@@ -98,9 +101,9 @@
 //
 // Temperature Sensors
 //
-#define TEMP_0_PIN                          PC3   // Analog Input //guessing
-#define TEMP_1_PIN                          PC4    // Analog Input //guessing
-#define TEMP_BED_PIN                        PC5   // Analog Input //guessing
+#define TEMP_0_PIN                          PC0   // Analog Input //may need switch for thermocouple/thermistor mode - unconfirmed
+#define TEMP_1_PIN                          PC1   // Analog Input //may need switch for thermocouple/thermistor mode - unconfirmed
+#define TEMP_BED_PIN                        PC3   // Analog Input //bed is thermistor mode only, confirmed
 
 //
 // Heaters / Fans
@@ -129,16 +132,16 @@
 //
 // LED / Lighting
 //
-//#define CASE_LIGHT_PIN_CI                 -1 //has two LED strip connectors (one RGB and one white only) - need to check those pins next
+#define CASE_LIGHT_PIN                 PC7 //board has two LED strip connectors (this is the on/off)
 //#define CASE_LIGHT_PIN_DO                 -1
-//#define NEOPIXEL_PIN                      -1
+//#define NEOPIXEL_PIN                      -1 //board supports RGB lightstrip, need to check pins 
 
 //
 // Misc. Functions
 //
 #define SDSS                                PC11 //unchecked, will test sd access later
-#define LED_PIN                             PC6   //confirmed
-#define PS_ON_PIN                           -1    //board has a power monitor socket, usage unclear
+#define LED_PIN                             PC6   //onboard LED , confirmed
+#define PS_ON_PIN                           -1    //board has a power monitor socket, pin PB2
 #define KILL_PIN                            -1
 #define POWER_LOSS_PIN                      -1    // Power-loss / nAC_FAULT
 
@@ -151,7 +154,7 @@
 // SD support
 //
 //#define SDIO_SUPPORT
-#define SD_DETECT_PIN                       -1 //unchecked, will test sd access later
+#define SD_DETECT_PIN                       PG15 //maybe? will test sd access later
 
 //
 // LCD / Controller
@@ -160,9 +163,9 @@
 // The LCD is initialized in FSMC mode
 #define BEEPER_PIN                          PD13 //confirmed
 
-#define BTN_EN1                             PE3 //unchecked, most likely wrong
-#define BTN_EN2                             PE4 //unchecked, most likely wrong
-#define BTN_ENC                             PE2 //unchecked, most likely wrong
+#define BTN_EN1                             PC14 //confirmed
+#define BTN_EN2                             PC15 //confirmed
+#define BTN_ENC                             PC13 //confirmed
 
 #define TFT_RESET_PIN                       PD6 //unchecked, most likely wrong
 #define TFT_BACKLIGHT_PIN                   PD3  //confirmed (well, the LCD is off, but I cannot see if it is only the backlight)

--- a/Marlin/src/pins/stm32f4/pins_LERDGE_S.h
+++ b/Marlin/src/pins/stm32f4/pins_LERDGE_S.h
@@ -101,8 +101,8 @@
 //
 // Temperature Sensors
 //
-#define TEMP_0_PIN                          PC0   // Analog Input //may need switch for thermocouple/thermistor mode - unconfirmed
-#define TEMP_1_PIN                          PC1   // Analog Input //may need switch for thermocouple/thermistor mode - unconfirmed
+#define TEMP_0_PIN                          PC0   // Analog Input //may need switch for thermocouple/thermistor mode - correct pin, wrong values
+#define TEMP_1_PIN                          PC1   // Analog Input //may need switch for thermocouple/thermistor mode - correct pin, wrong values
 #define TEMP_BED_PIN                        PC3   // Analog Input //bed is thermistor mode only, confirmed
 
 //
@@ -112,15 +112,18 @@
 #define HEATER_1_PIN                        PA1 //confirmed
 #define HEATER_BED_PIN                      PA3 //confirmed
 
+
 #ifndef FAN_PIN
-  //#define FAN_PIN                         PA15
+  #define FAN_PIN                         PA15
 #endif
-#define FAN1_PIN                            PA15 //heater 0 fan 1 //confirmed
-#define FAN2_PIN                            PB10 //heater 1 fan 2 //confirmed
-#define FAN3_PIN                            PF5  //heater 0 fan 2 and heater 1 fan 2 (two sockets, switched together) //confirmed
+
+//#define FAN0_PIN                            PA15 //heater 0 fan 1 //confirmed
+#define FAN1_PIN                            PB10 //heater 1 fan 2 //confirmed
+#define FAN2_PIN                            PF5  //heater 0 fan 2 and heater 1 fan 2 (two sockets, switched together) //confirmed
+
 
 #ifndef E0_AUTO_FAN_PIN
-  #define E0_AUTO_FAN_PIN                   PF5  // FAN3_PIN
+  #define E0_AUTO_FAN_PIN                   FAN2_PIN
 #endif
 
 //

--- a/Marlin/src/pins/stm32f4/pins_LERDGE_S.h
+++ b/Marlin/src/pins/stm32f4/pins_LERDGE_S.h
@@ -35,88 +35,89 @@
 //
 // Servos
 //
-//#define SERVO0_PIN                        PD12
+//#define SERVO0_PIN                        PD12 //unchecked, most likely wrong, board has a servo connector
 //#define SERVO1_PIN                        -1
 
 //
 // Limit Switches
 //
-#define X_STOP_PIN                          PB12
-#define Y_STOP_PIN                          PB13
-#define Z_STOP_PIN                          PB14
+#define X_STOP_PIN                          PB12 //unchecked, most likely wrong
+#define Y_STOP_PIN                          PB13 //unchecked, most likely wrong
+#define Z_STOP_PIN                          PB14 //unchecked, most likely wrong
 
 //
 // Filament runout
 //
-#define FIL_RUNOUT_PIN                      PE1
+#define FIL_RUNOUT_PIN                      PE1 //unchecked, most likely wrong
 
 //
 // Z Probe (when not Z_MIN_PIN)
 //
 //#ifndef Z_MIN_PROBE_PIN
-//  #define Z_MIN_PROBE_PIN  PB15
+//  #define Z_MIN_PROBE_PIN  PB15 //unchecked, most likely wrong, board has a probe switch connector
 //#endif
 
 //
 // Steppers
 //
-#define X_STEP_PIN                          PB10
-#define X_DIR_PIN                           PB2
-#define X_ENABLE_PIN                        PB11
+#define X_STEP_PIN                          PF7 //confirmed 
+#define X_DIR_PIN                           PF8 //confirmed 
+#define X_ENABLE_PIN                        PF6 //confirmed 
 //#ifndef X_CS_PIN
-//  #define X_CS_PIN                        PD1
+//  #define X_CS_PIN                        -1 //no idea
 //#endif
 
-#define Y_STEP_PIN                          PB0
-#define Y_DIR_PIN                           PC5
-#define Y_ENABLE_PIN                        PB1
+#define Y_STEP_PIN                          PF10 //confirmed 
+#define Y_DIR_PIN                           PF11 //confirmed 
+#define Y_ENABLE_PIN                        PF9  //confirmed 
 //#ifndef Y_CS_PIN
-//  #define Y_CS_PIN                        PE12
+//  #define Y_CS_PIN                        -1 //no idea
 //#endif
 
-#define Z_STEP_PIN                          PA7
-#define Z_DIR_PIN                           PA6
-#define Z_ENABLE_PIN                        PC4
+#define Z_STEP_PIN                          PF13 //confirmed 
+#define Z_DIR_PIN                           PF14 //confirmed 
+#define Z_ENABLE_PIN                        PF12 //confirmed 
 //#ifndef Z_CS_PIN
-//  #define Z_CS_PIN                        PD5
+//  #define Z_CS_PIN                        -1 //no idea
 //#endif
 
-#define E0_STEP_PIN                         PA4
-#define E0_DIR_PIN                          PA3
-#define E0_ENABLE_PIN                       PA5
+#define E0_STEP_PIN                         PG0 //confirmed
+#define E0_DIR_PIN                          PG1 //confirmed
+#define E0_ENABLE_PIN                       PF15 //confirmed
 //#ifndef E0_CS_PIN
-//  #define E0_CS_PIN                       PB4
+//  #define E0_CS_PIN                       -1 //no idea
 //#endif
 
-#define E1_STEP_PIN                         -1
-#define E1_DIR_PIN                          -1
-#define E1_ENABLE_PIN                       -1
+#define E1_STEP_PIN                         PG3 //confirmed
+#define E1_DIR_PIN                          PG4 //confirmed
+#define E1_ENABLE_PIN                       PG2 //confirmed
 //#ifndef E1_CS_PIN
-//  #define E1_CS_PIN                       PE5
+//  #define E1_CS_PIN                       -1 //no idea
 //#endif
 
 //
 // Temperature Sensors
 //
-#define TEMP_0_PIN                          PC0   // Analog Input
-#define TEMP_1_PIN                          -1    // Analog Input
-#define TEMP_BED_PIN                        PC1   // Analog Input
+#define TEMP_0_PIN                          PC3   // Analog Input //guessing
+#define TEMP_1_PIN                          PC4    // Analog Input //guessing
+#define TEMP_BED_PIN                        PC5   // Analog Input //guessing
 
 //
 // Heaters / Fans
 //
-#define HEATER_0_PIN                        PA1
-#define HEATER_1_PIN                        -1
-#define HEATER_BED_PIN                      PA2
+#define HEATER_0_PIN                        PA0 //confirmed
+#define HEATER_1_PIN                        PA1 //confirmed
+#define HEATER_BED_PIN                      PA3 //confirmed
 
 #ifndef FAN_PIN
-  //#define FAN_PIN                         PC15
+  //#define FAN_PIN                         PA15
 #endif
-#define FAN1_PIN                            PC15
-#define FAN2_PIN                            PA0
+#define FAN1_PIN                            PA15 //heater 0 fan 1 //confirmed
+#define FAN2_PIN                            PB10 //heater 1 fan 2 //confirmed
+#define FAN3_PIN                            PF5  //heater 0 fan 2 and heater 1 fan 2 (two sockets, switched together) //confirmed
 
 #ifndef E0_AUTO_FAN_PIN
-  #define E0_AUTO_FAN_PIN                   PC15  // FAN1_PIN
+  #define E0_AUTO_FAN_PIN                   PF5  // FAN3_PIN
 #endif
 
 //
@@ -128,51 +129,51 @@
 //
 // LED / Lighting
 //
-//#define CASE_LIGHT_PIN_CI                 -1
+//#define CASE_LIGHT_PIN_CI                 -1 //has two LED strip connectors (one RGB and one white only) - need to check those pins next
 //#define CASE_LIGHT_PIN_DO                 -1
 //#define NEOPIXEL_PIN                      -1
 
 //
 // Misc. Functions
 //
-#define SDSS                                PC11
-#define LED_PIN                             PC7   // Alive
-#define PS_ON_PIN                           -1
+#define SDSS                                PC11 //unchecked, will test sd access later
+#define LED_PIN                             PC6   //confirmed
+#define PS_ON_PIN                           -1    //board has a power monitor socket, usage unclear
 #define KILL_PIN                            -1
 #define POWER_LOSS_PIN                      -1    // Power-loss / nAC_FAULT
 
-#define SCK_PIN                             PC12
-#define MISO_PIN                            PC8
-#define MOSI_PIN                            PD2
-#define SS_PIN                              PC11
+#define SCK_PIN                             PC12 //unchecked, will test sd access later
+#define MISO_PIN                            PC8  //unchecked, will test sd access later
+#define MOSI_PIN                            PD2 //unchecked, will test sd access later
+#define SS_PIN                              PC11 //unchecked, will test sd access later
 
 //
 // SD support
 //
 //#define SDIO_SUPPORT
-#define SD_DETECT_PIN                       -1
+#define SD_DETECT_PIN                       -1 //unchecked, will test sd access later
 
 //
 // LCD / Controller
 //
 
 // The LCD is initialized in FSMC mode
-#define BEEPER_PIN                          PD12
+#define BEEPER_PIN                          PD13 //confirmed
 
-#define BTN_EN1                             PE3
-#define BTN_EN2                             PE4
-#define BTN_ENC                             PE2
+#define BTN_EN1                             PE3 //unchecked, most likely wrong
+#define BTN_EN2                             PE4 //unchecked, most likely wrong
+#define BTN_ENC                             PE2 //unchecked, most likely wrong
 
-#define TFT_RESET_PIN                       PD6
-#define TFT_BACKLIGHT_PIN                   PD3
+#define TFT_RESET_PIN                       PD6 //unchecked, most likely wrong
+#define TFT_BACKLIGHT_PIN                   PD3  //confirmed (well, the LCD is off, but I cannot see if it is only the backlight)
 
-#define TFT_CS_PIN                         PD7
-#define TFT_RS_PIN                         PD11
+#define TFT_CS_PIN                         PD7 //TFT works, so all ok?
+#define TFT_RS_PIN                         PD11 //TFT works, so all ok?
 
-#define TOUCH_CS_PIN                        PB6
-#define TOUCH_SCK_PIN                       PB3
-#define TOUCH_MOSI_PIN                      PB5
-#define TOUCH_MISO_PIN                      PB4
+#define TOUCH_CS_PIN                        PB6 //there is touch, but calibration is off
+#define TOUCH_SCK_PIN                       PB3 //there is touch, but calibration is off
+#define TOUCH_MOSI_PIN                      PB5 //there is touch, but calibration is off
+#define TOUCH_MISO_PIN                      PB4 //there is touch, but calibration is off
 
 //
 // ST7920 Delays

--- a/Marlin/src/pins/stm32f4/pins_LERDGE_S.h
+++ b/Marlin/src/pins/stm32f4/pins_LERDGE_S.h
@@ -57,7 +57,7 @@
 // Z Probe (when not Z_MIN_PIN)
 //
 #ifndef Z_MIN_PROBE_PIN
-  #define Z_MIN_PROBE_PIN  PG815 //confirmed
+  #define Z_MIN_PROBE_PIN  PG8 //confirmed
 #endif
 
 //

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,7 @@
 [platformio]
 src_dir      = Marlin
 boards_dir   = buildroot/share/PlatformIO/boards
-default_envs = mega2560
+default_envs = LERDGEX
 extra_configs = extra_config.ini
 
 #
@@ -848,7 +848,7 @@ build_flags       = ${common_stm32.build_flags}
   -DTRANSFER_CLOCK_DIV=8
   -DVECT_TAB_OFFSET=0x10000
   -DVECT_TAB_ADDR=0x8010000
-  -DFIRMWARE=Lerdge_X_firmware_force.bin
+  -DFIRMWARE=Lerdge_firmware_force.bin
 build_unflags     = ${common_stm32.build_unflags} -DUSBCON -DUSBD_USE_CDC -DUSBD_VID=0x0483
 
 #


### PR DESCRIPTION

### Description

Complete pins file and example configuration for Lerdge-S. Only remaining issue is the thermistor inputs. The Lerdge-S board has a max6675 chip onboard and can select thermistor or thermocouple use in software. I am sure the pins are correct, as I found a set of pins (on the expansion board interface) that allow marlin to read temperatures in the correct range - I touched them by accident, and for a short time the LCD shows correct values. 

### Benefits

Get the correct pins for the Lerdge-S board.

### Related Issues

