### PR TITLE
Unified stm32 bootloader support

### DIFF
--- a/buildroot/share/PlatformIO/ldscripts/lerdge.ld
+++ b/buildroot/share/PlatformIO/ldscripts/lerdge.ld
@@ -40,8 +40,8 @@ _Min_Stack_Size = 0x400;; /* required amount of stack */
 /* Specify the memory areas */
 MEMORY
 {
-FLASH (rx)      : ORIGIN = 0x8010000, LENGTH = 448K
-RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 128K
+FLASH (rx)      : ORIGIN = 0x8000000 + LD_FLASH_OFFSET, LENGTH = LD_MAX_SIZE - LD_FLASH_OFFSET
+RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = LD_MAX_DATA_SIZE
 CCMRAM (rw)      : ORIGIN = 0x10000000, LENGTH = 64K
 }
 

--- a/buildroot/share/PlatformIO/scripts/stm32_bootloader.py
+++ b/buildroot/share/PlatformIO/scripts/stm32_bootloader.py
@@ -1,0 +1,30 @@
+import os,sys,shutil
+Import("env")
+
+from SCons.Script import DefaultEnvironment
+board = DefaultEnvironment().BoardConfig()
+
+def noencrypt(source, target, env):
+  firmware = os.path.join(target[0].dir.path, board.get("build.firmware"))
+  # do not overwrite encrypted firmware if present
+  if not os.path.isfile(firmware):
+    shutil.copy(target[0].path, firmware)
+
+if 'offset' in board.get("build").keys():
+  LD_FLASH_OFFSET = board.get("build.offset")
+
+  for define in env['CPPDEFINES']:
+    if define[0] == "VECT_TAB_OFFSET":
+      env['CPPDEFINES'].remove(define)
+  env['CPPDEFINES'].append(("VECT_TAB_OFFSET", LD_FLASH_OFFSET))
+
+  maximum_ram_size = board.get("upload.maximum_ram_size")
+
+  for i, flag in enumerate(env["LINKFLAGS"]):
+    if "-Wl,--defsym=LD_FLASH_OFFSET" in flag:
+      env["LINKFLAGS"][i] = "-Wl,--defsym=LD_FLASH_OFFSET=" + LD_FLASH_OFFSET
+    if "-Wl,--defsym=LD_MAX_DATA_SIZE" in flag:
+      env["LINKFLAGS"][i] = "-Wl,--defsym=LD_MAX_DATA_SIZE=" + str(maximum_ram_size - 40)
+
+  if 'firmware' in board.get("build").keys():
+    env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", noencrypt);

--- a/platformio.ini
+++ b/platformio.ini
@@ -817,41 +817,40 @@ lib_ignore        = Adafruit NeoPixel, SailfishLCD, SlowSoftI2CMaster, SoftwareS
 # Lerdge base
 #
 [lerdge_common]
-platform          = ${common_stm32.platform}
-extends           = common_stm32
-board             = LERDGE
-extra_scripts     = pre:buildroot/share/PlatformIO/scripts/copy_marlin_variant_to_framework.py
-                    buildroot/share/PlatformIO/scripts/lerdge.py
-build_flags       = ${common_stm32.build_flags}
+platform           = ${common_stm32.platform}
+extends            = common_stm32
+board              = LERDGE
+board_build.offset = 0x10000
+extra_scripts      = pre:buildroot/share/PlatformIO/scripts/copy_marlin_variant_to_framework.py
+                     buildroot/share/PlatformIO/scripts/stm32_bootloader.py
+                     buildroot/share/PlatformIO/scripts/lerdge.py
+build_flags        = ${common_stm32.build_flags}
   -DSTM32F4 -DSTM32F4xx -DTARGET_STM32F4
   -DDISABLE_GENERIC_SERIALUSB -DARDUINO_ARCH_STM32 -DARDUINO_LERDGE
   -DTRANSFER_CLOCK_DIV=8
-  -DVECT_TAB_OFFSET=0x10000
-build_unflags     = ${common_stm32.build_unflags} -DUSBCON -DUSBD_USE_CDC -DUSBD_VID=0x0483
+build_unflags      = ${common_stm32.build_unflags} -DUSBCON -DUSBD_USE_CDC -DUSBD_VID=0x0483
 
 #
 # Lerdge X
 #
 [env:LERDGEX]
-extends           = lerdge_common
-build_flags       = ${lerdge_common.build_flags}
-  -DFIRMWARE=Lerdge_X_firmware_force.bin
+extends              = lerdge_common
+board_build.firmware = Lerdge_X_firmware_force.bin
 
 #
 # Lerdge S
 #
 [env:LERDGES]
-extends           = lerdge_common
-build_flags       = ${lerdge_common.build_flags}
-  -DFIRMWARE=Lerdge_firmware_force.bin
+extends              = lerdge_common
+board_build.firmware = Lerdge_firmware_force.bin
 
 #
 # Lerdge K
 #
 [env:LERDGEK]
-extends           = lerdge_common
-build_flags       = ${lerdge_common.build_flags}
-  -DFIRMWARE=Lerdge_K_firmware_force.bin
+extends              = lerdge_common
+board_build.firmware = Lerdge_K_firmware_force.bin
+build_flags          = ${lerdge_common.build_flags}
   -DLERDGEK
 
 #


### PR DESCRIPTION
I've changed bootloader handling somewhere along the way.
Bootloader support and encryption were separated to create a single unified bootloader script for HAL STM32.

Bootloader script handles linker's variables used in .ld file, sets VECT_TAB_OFFSET build parameter and optionally creates unencrypted firmware with custom name (needed for SKR Mini and Alfawise Ux0 boards). Firmare offset is defined by `build.offset` board's parameter. This parameter can be configured in json file with board definition or in platformio.ini

Firmware's filename parameter was moved from build parameters to board's parameter `build.firmware`.
Encryption script uses this parameter to save encrypted firmware into specific file.
I've created `mks_encrypt.py` scrypt to handle encryption for all variants on MKS Robin boards.

Please test this code before merging. I've tested it on SKR Mini and MSK Robin boards but I have no hardware to test Lerdge environments.
